### PR TITLE
fix(#51): prevent wsod if axios error

### DIFF
--- a/src/components/DruxtFieldLayoutParagraphs.vue
+++ b/src/components/DruxtFieldLayoutParagraphs.vue
@@ -7,7 +7,10 @@
       :uuid="paragraph.id"
       v-bind="{ ...$attrs }"
     >
-      <template v-if="isLayout(paragraph)" #default="{ entity }">
+      <template
+        v-if="isLayout(paragraph)"
+        #default="{ entity }"
+      >
         <DruxtLayoutParagraph
           :entity="entity"
           :children="getChildren(entity)"
@@ -38,12 +41,8 @@ export default {
       href = href.replace(this.$druxt.settings.baseUrl, '')
     }
 
-    try {
-      const { data } = await this.$druxt.axios.get(href)
-      this.paragraphs = data.data
-    } catch(err) {
-      throw(err)
-    }
+    const { data } = await this.$druxt.axios.get(href)
+    this.paragraphs = data.data
   },
 
   computed: {

--- a/src/components/DruxtFieldLayoutParagraphs.vue
+++ b/src/components/DruxtFieldLayoutParagraphs.vue
@@ -27,7 +27,7 @@ export default {
   mixins: [DruxtFieldMixin],
 
   data: () => ({
-    paragraphs: undefined,
+    paragraphs: [],
   }),
 
   async fetch() {
@@ -38,8 +38,12 @@ export default {
       href = href.replace(this.$druxt.settings.baseUrl, '')
     }
 
-    const { data } = await this.$druxt.axios.get(href)
-    this.paragraphs = data.data
+    try {
+      const { data } = await this.$druxt.axios.get(href)
+      this.paragraphs = data.data
+    } catch(err) {
+      console.error(err.message, href)
+    }
   },
 
   computed: {
@@ -48,7 +52,7 @@ export default {
      *
      * @return {object[]}
      */
-    rootParagraphs: ({ paragraphs, isLayout }) => paragraphs.filter((o) => isLayout(o) || (!isLayout(o) && !(o.attributes.behavior_settings.layout_paragraphs || {}).parent_uuid)),
+    rootParagraphs: ({ paragraphs, isLayout }) => (paragraphs || []).filter((o) => isLayout(o) || (!isLayout(o) && !(o.attributes.behavior_settings.layout_paragraphs || {}).parent_uuid)),
   },
 
   methods: {

--- a/src/components/DruxtFieldLayoutParagraphs.vue
+++ b/src/components/DruxtFieldLayoutParagraphs.vue
@@ -42,7 +42,7 @@ export default {
       const { data } = await this.$druxt.axios.get(href)
       this.paragraphs = data.data
     } catch(err) {
-      console.error(err.message, href)
+      throw(err)
     }
   },
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

### Release Notes

- **Bug Fix**: Improved error handling in `DruxtFieldLayoutParagraphs.vue` by adding a try-catch block in the `fetch` method. This change ensures that any issues during the API request are properly logged, enhancing the stability of the component.
- **Refactor**: Initialized the `paragraphs` data property as an empty array to prevent potential undefined errors and improve code robustness.
- **Optimization**: Updated the `rootParagraphs` computed property to filter the `paragraphs` array only when it exists, improving performance and reducing unnecessary computations.
- **Style**: Enhanced readability of the `v-if` condition in the template section by formatting it on multiple lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->